### PR TITLE
Automatischer Upload zu Monlist

### DIFF
--- a/MONI/App.xaml.cs
+++ b/MONI/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Windows;
 using MONI.Util;
+using MONI.Views;
 
 namespace MONI
 {
@@ -12,6 +13,35 @@ namespace MONI
         protected override void OnStartup(StartupEventArgs e)
         {
             AppHelper.Instance.ConfigureApp(this, Assembly.GetExecutingAssembly().GetName().Name);
+
+            // Check command line arguments for automatic upload
+            var arguments = e.Args;
+            var windowMode = true;
+            string password = "";
+            foreach (var arg in e.Args)
+            {
+                var values = arg.Split('=');
+                switch(values[0])
+                {
+                    case "windowmode":
+                      if (values[1] == "false")
+                      {
+                          windowMode = false;
+                      }
+                      break;
+
+                    case "password":
+                      password = values[1];
+                      break;
+                }
+            }
+            if (!windowMode)
+            {
+                var MV = new MainView();
+                MV.uploadWrapper(password);
+                MV.Close();
+            }
+
             base.OnStartup(e);
         }
     }

--- a/MONI/Views/MainView.xaml.cs
+++ b/MONI/Views/MainView.xaml.cs
@@ -391,6 +391,11 @@ namespace MONI.Views
             }
         }
 
+        public void uploadWrapper(string password)
+        {
+            UploadToMonlist(password);
+        }
+
         private void UploadToMonlist(string password)
         {
             string user = this.ViewModel.Settings.MainSettings.MonlistEmployeeNumber;


### PR DESCRIPTION
Einige Kollegen hatten den Wunsch, den Monlist-Upload aus MONI automatisiert anstoßen zu können.

Dazu habe ich die Möglichkeit geschaffen, MONI aus der Konsole so aufzurufen, dass nur der Upload zu Monlist ausgeführt wird.

Um dies zu tun, muss im CMD der Aufruf
`MONI.exe windowmode=false password=PW`
erfolgen.
Dabei wäre PW durch das Monlist-Passwort des Nutzers zu ersetzen.