### PR TITLE
Small fixes

### DIFF
--- a/MONI/Views/ViewTemplates.xaml
+++ b/MONI/Views/ViewTemplates.xaml
@@ -37,7 +37,7 @@
                                HorizontalAlignment="Center"
                                FontSize="10"
                                Foreground="{StaticResource lightText}"
-                               Text="{Binding HoursDuration}" />
+                               Text="{Binding HoursDuration, StringFormat='{}{0:f}'}" />
                 </Grid>
             </Border>
             <UniformGrid Columns="2" IsHitTestVisible="False">

--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ Konfiguration:
 
 Eingabe: 
 
-**8:30,4.25;ctb(support),2.75;ktl(spezifikation schnittstelle),1;ktl(+ bahn)**
+**8:30,4.25;ctb(support),2.75;ktl(schnittstelle spezifiziert),1;ktl(+ bahnschnittstelle)**
 
 Ausgabe: 
 
 - 8:30-12:45 12345-000  support
-- 12:45-15:30 54321-000  spezifikation schnittstelle
-- 15:30-17:30 54321-000  spezifikation schnittstelle bahn
+- 12:45-15:30 54321-000  schnittstelle spezifiziert
+- 15:30-17:30 54321-000  spezifikation bahnschnittstelle
 
 Erläuterung: 
 


### PR DESCRIPTION
Hallo zusammen,

ich habe mit dem Branch, zu warm werden, zwei kleine "Fehler" behoben. Vieleicht habt Ihr Interesse daran.

1. Ich glaube, dass ein Beispiel in der Readme-Datei fehlerhaft ist.

2. Ich habe eine Formatierung für die Arbeitszeitanzeige in der Monatsübersicht hinzugefügt. Vor der "Korrektur" kann es passieren, das mehr als 2 Nachkommastellen angezeigt werden, und die Breite der Monatsübersicht sich stark ausdehnte. (Fällt nur auf, wenn man sich nicht an die 15min Regel hält :)

Viele Grüße
Jonathan