### PR TITLE
HoursDuration 0 vs null

### DIFF
--- a/MONI.Tests/HoursDuration_Tester.cs
+++ b/MONI.Tests/HoursDuration_Tester.cs
@@ -74,5 +74,36 @@ namespace MONI.Tests
             Assert.NotNull(scs);
             Assert.AreEqual(8, scs.UsedInMonth);
         }
+
+        [Test]
+        public void HoursDuration_EmptyWorkDaySchouldReturnNull()
+        {
+            WorkDay wd = new WorkDay(2011, 1, 1, null);
+            Assert.IsTrue(wd.IsEmpty());
+            Assert.AreEqual(null, wd.HoursDuration);
+        }
+
+        [Test]
+        public void HoursDuration_WorkDayWithOutEmptyOriginalStringSchouldReturn0()
+        { //white spaces do not count!
+            WorkDay wd = new WorkDay(2011, 1, 1, null);
+            wd.OriginalString = "!";
+            Assert.AreEqual(0, wd.HoursDuration);
+        }
+
+        [Test]
+        public void HoursDuration_EmptyWorkWeekSchouldReturn0()
+        {
+            WorkMonth wm = new WorkMonth(2011, 1, null, new WorkDayParserSettings(), 1);
+            WorkWeek ww = new WorkWeek(wm, 1);
+            Assert.AreEqual(0, ww.HoursDuration);
+        }
+
+        [Test]
+        public void HoursDuration_EmptyWorkMonthSchouldReturn0()
+        {
+            WorkMonth wm = new WorkMonth(2011, 1, null, new WorkDayParserSettings(), 1);
+            Assert.AreEqual(0, wm.HoursDuration);
+        }
     }
 }

--- a/MONI.Tests/WorkDayParserMainTester.cs
+++ b/MONI.Tests/WorkDayParserMainTester.cs
@@ -609,5 +609,16 @@ namespace MONI.Tests
             var workItemParserResult = wdp.Parse("7:30,-11;11111-111,-11:45;11111-111,-12:15;11111-111,-15;11111-111", ref wd);
             Assert.IsFalse(workItemParserResult.Success, workItemParserResult.Error);
         }
+
+        [Test]
+        public void WDParser_DidNotWorkThisDay()
+        {
+            WorkDay wd = new WorkDay(1, 1, 1, null);
+            WorkDayParser wdp = new WorkDayParser();
+            var workItemParserResult = wdp.Parse("!,", ref wd);
+            Assert.IsTrue(workItemParserResult.Success, workItemParserResult.Error);
+            Assert.IsEmpty(workItemParserResult.Error);
+            CollectionAssert.IsEmpty(wd.Items);
+        }
     }
 }

--- a/MONI.Tests/WorkDayParserMainTester.cs
+++ b/MONI.Tests/WorkDayParserMainTester.cs
@@ -42,7 +42,7 @@ namespace MONI.Tests
             Assert.IsEmpty(workItemParserResult.Error);
             wd.OriginalString = string.Empty;
             CollectionAssert.IsEmpty(wd.Items);
-            Assert.AreEqual(0, wd.HoursDuration);
+            Assert.AreEqual(null, wd.HoursDuration);
         }
 
         [Test]

--- a/MONI/Data/WorkDay.cs
+++ b/MONI/Data/WorkDay.cs
@@ -135,7 +135,7 @@ namespace MONI.Data
 
         public bool IsEmpty()
         {
-            return string.IsNullOrWhiteSpace(this.OriginalString);
+            return string.IsNullOrWhiteSpace(this.OriginalString) && this.Items.Count() == 0;
         }
 
         private void ParseData(string value)
@@ -166,9 +166,9 @@ namespace MONI.Data
             }
         }
 
-        public double HoursDuration
+        public double? HoursDuration
         {
-            get { return this.Items.Sum(i => i.HoursDuration); }
+            get { return this.IsEmpty() ? null : (double?)this.Items.Sum(i => i.HoursDuration); }
         }
 
         public DayOfWeek DayOfWeek { get; set; }

--- a/MONI/Data/WorkMonth.cs
+++ b/MONI/Data/WorkMonth.cs
@@ -197,7 +197,7 @@ namespace MONI.Data
         public void CalcPreviewHours()
         {
             this.NecessaryHours = this.Weeks.SelectMany(w => w.Days).Count(d => d.DayType == DayType.Working) * hoursPerDay;
-            this.PreviewHours = this.HoursDuration + this.Weeks.SelectMany(w => w.Days).Count(d => d.DayType == DayType.Working && d.HoursDuration == 0) * hoursPerDay;
+            this.PreviewHours = this.HoursDuration + this.Weeks.SelectMany(w => w.Days).Count(d => d.DayType == DayType.Working && d.HoursDuration == null) * hoursPerDay;
         }
 
         public override string ToString()

--- a/MONI/Data/WorkWeek.cs
+++ b/MONI/Data/WorkWeek.cs
@@ -27,7 +27,7 @@ namespace MONI.Data
 
         public double HoursDuration
         {
-            get { return this.Days.Sum(i => i.HoursDuration); }
+            get { return this.Days.Sum(i => i.HoursDuration ?? 0); }
         }
 
         public IEnumerable<WorkDay> Days

--- a/MONI/Parser/WorkDayParser.cs
+++ b/MONI/Parser/WorkDayParser.cs
@@ -48,7 +48,12 @@ namespace MONI.Data
                 string error;
                 // should be like "<daystarttime>,..."
                 // eg 7,... or 7:30,...
-                if (this.GetDayStartTime(userInput, out dayStartTime, out remainingString, out error))
+
+                if (this.ForceDurationToZero(userInput))
+                {
+                    ret.Success = true;
+                }
+                else if (this.GetDayStartTime(userInput, out dayStartTime, out remainingString, out error))
                 {
                     // proceed with parsing items
                     var parts = remainingString.SplitWithIgnoreRegions(new[] { itemSeparator }, new IgnoreRegion('(', ')'));
@@ -350,6 +355,15 @@ namespace MONI.Data
                 return string.Format("{0}-{1}", beforeDescription.TokenReturnInputIfFail("-", 1), posReplacement);
             }
             return beforeDescription;
+        }
+
+        private bool ForceDurationToZero(string input)
+        {
+            var dayStartToken = input.Token(dayStartSeparator.ToString(), 1, input); // do not trim here, need original length later
+            bool forceDurationToZero = dayStartToken.Trim().Equals(pauseChar.ToString());
+            bool noFurtherItemsToParse = dayStartToken.Length + 1 >= input.TrimEnd().Length;
+
+            return forceDurationToZero && noFurtherItemsToParse;
         }
 
         private bool GetDayStartTime(string input, out TimeItem dayStartTime, out string remainingString, out string error)

--- a/MONI/ValueConverter/DurationBGColorConverter.cs
+++ b/MONI/ValueConverter/DurationBGColorConverter.cs
@@ -35,9 +35,9 @@ namespace MONI.ValueConverter
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var duration = (double)value;
+            var duration = (double?)value;
             var b = this.defaultBrush;
-            if (duration < MoniSettings.Current.MainSettings.HoursPerDay)
+            if (duration != null && duration < MoniSettings.Current.MainSettings.HoursPerDay)
             {
                 b = this.lessHoursPerDayBrush;
             }

--- a/MONI/ValueConverter/DurationFGColorConverter.cs
+++ b/MONI/ValueConverter/DurationFGColorConverter.cs
@@ -35,9 +35,9 @@ namespace MONI.ValueConverter
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var duration = (double)value;
+            var duration = (double?)value;
             var b = this.defaultBrush;
-            if (duration < MoniSettings.Current.MainSettings.HoursPerDay)
+            if (duration != null && duration < MoniSettings.Current.MainSettings.HoursPerDay)
             {
                 b = this.lessHoursPerDayBrush;
             }

--- a/MONI/ValueConverter/DurationToStringConverter.cs
+++ b/MONI/ValueConverter/DurationToStringConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+using MONI.Data;
+
+namespace MONI.ValueConverter
+{
+    public class DurationToStringConverter : IValueConverter
+    {
+        private static DurationToStringConverter instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static DurationToStringConverter()
+        {
+        }
+
+        private DurationToStringConverter()
+        {
+        }
+
+        public static DurationToStringConverter Instance
+        {
+            get { return instance ?? (instance = new DurationToStringConverter()); }
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var duration = (double?)value;
+            var durationString = duration != null ? string.Format("{0:f} h", duration) : string.Empty;
+            return durationString;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}

--- a/MONI/Views/MainView.xaml
+++ b/MONI/Views/MainView.xaml
@@ -615,7 +615,7 @@
                                            Background="{Binding HoursDuration, Converter={x:Static valueConverter:DurationBGColorConverter.Instance}}"
                                            FontWeight="Bold"
                                            Foreground="{Binding HoursDuration, Converter={x:Static valueConverter:DurationFGColorConverter.Instance}}"
-                                           Text="{Binding HoursDuration, StringFormat='{}{0:f} h'}" />
+                                           Text="{Binding HoursDuration, Mode=OneWay, Converter={x:Static valueConverter:DurationToStringConverter.Instance}}" />
 
                                 <TextBox x:Name="userEntry"
                                          Grid.Row="0"

--- a/README.md
+++ b/README.md
@@ -327,6 +327,15 @@ Erläuterung:
 
 Statt der Stunden Anzahl kann auch eine Zeit eingegeben werden, diese muß dann mit **-** prefixed werden. Automatische Pausen werden dabei ebenfalls berücksichtigt.
 
+## Geleistete Arbeitszeit eines Tages auf 0 h festsetzen ##
+
+Eingabe:
+
+**!**
+
+Erläuterung: 
+
+Dieser Tag wird mit 0 geleisteten Stunden bei der prognostizierten Arbeitszeit eingerechnet.
 
 
 


### PR DESCRIPTION
Hi nochmal,

so jetzt kommt meine eigentliche Änderung. Ich wollte die Möglichkeit schaffen durch eine bestimmte Eingabe, die Arbeitszeit eines Tages von 0 Stunden auch in der prognostizierten Arbeitszeit eines Monats zu berücksichtigen. Dies ist für mich interessant, wenn ich Überstunden durch einen freien Tag abbauen will.
Bisher werden alle Tage mit einer Arbeitszeit von 0 Stunden als noch nicht bearbeitet angesehen und mit der vollen Stundenzahl in die Prognose eingerechnet.

Um unterscheiden zu können zwischen einer Arbeitszeit von 0 Stunden und einem leeren Eintrag habe ich die Member-Variable 'WorkDay.HoursDuration' nullable gestaltet.

'WorkDay.HoursDuration' gibt nun 'null' zurück wenn 'WorkDay.IsEmpty()' zutrifft.

Mit diesen neuen Möglichkeiten habe ich auch die Anzeige in der Oberfläche angepasst.
Für Tage wo 'WorkDay.IsEmpty()' zutrifft wird jetzt keine Arbeitszeit mehr in der Oberfläche angezeigt.
Erst wenn man Einträge für den Tag tätigt und 'WorkDay.HoursDuration != null' ist wird die entsprechende Zeit angezeigt.

Um Tage auf 0 Stunden zu setzen habe ich erlaubt einen Tag mit "!," zu starten.
Es ist bisher auch möglich Tage auf 0 Stunden zu setzen indem man nur eine Startzeit einträgt z.B. "8,".

Mich würde es freuen, wenn euch diese Anpassung gefällt und Ihr sie mit aufnehmt.
Bei Fragen kommt gerne auf mich zu.

Viele Grüße
Jonathan